### PR TITLE
fix:버셀오류수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@floating-ui/dom": "^1.7.5",
     "@clerk/clerk-react": "^5.60.0",
+    "@floating-ui/dom": "^1.7.5",
     "@tailwindcss/vite": "^4.1.13",
     "@tanstack/react-query": "^5.89.0",
     "@tiptap/core": "^3.18.0",

--- a/src/pages/report/report-create-page.tsx
+++ b/src/pages/report/report-create-page.tsx
@@ -26,7 +26,7 @@ const ReportCreatePage = () => {
   const navigate = useNavigate();
   const toggleCheckbox = (id: string) => {
     setSelectedIds((prev) =>
-      prev.includes(id) ? prev.filter((itemId) => itemId !== id) : [...prev, id],
+      prev.indexOf(id) !== -1 ? prev.filter((itemId) => itemId !== id) : [...prev, id],
     );
   };
 
@@ -40,7 +40,7 @@ const ReportCreatePage = () => {
               key={item.id}
               title={item.title}
               description={item.description}
-              isActive={selectedIds.includes(item.id)}
+              isActive={selectedIds.indexOf(item.id) !== -1}
               onClick={() => toggleCheckbox(item.id)}
             />
           ))}

--- a/src/shared/components/common/ProfileBase.tsx
+++ b/src/shared/components/common/ProfileBase.tsx
@@ -95,7 +95,7 @@ export function BadgeList({ badges, className }: BadgeListProps) {
   return (
     <div className={cn('flex flex-wrap gap-4', className)}>
       {badges.map((badge, index) => (
-        <Badge key={`${badge.label}-${index}`} label={badge.label} />
+        <Badge key={badge.id ?? `${badge.label}-${index}`} label={badge.label} />
       ))}
     </div>
   );

--- a/src/shared/components/common/RecommendDeveloperCard.tsx
+++ b/src/shared/components/common/RecommendDeveloperCard.tsx
@@ -60,10 +60,10 @@ export default function RecommendDeveloperCard({
     v
       .trim()
       .toLowerCase()
-      .replaceAll(' ', '')
-      .replaceAll('.', '')
-      .replaceAll('-', '')
-      .replaceAll('_', '');
+      .replace(/\s/g, '')
+      .replace(/\./g, '')
+      .replace(/-/g, '')
+      .replace(/_/g, '');
 
   const ALL_TECH_STACK_BADGES: Array<Extract<TechStackChip, { off: string; on: string }>> = [
     ...FRONTEND_LANGUAGE_FRAMEWORK,
@@ -76,7 +76,7 @@ export default function RecommendDeveloperCard({
   ].filter((b): b is Extract<TechStackChip, { off: string; on: string }> => 'off' in b && 'on' in b);
 
   const TECH_BADGE_BY_NAME = new Map<string, Extract<TechStackChip, { off: string; on: string }>>(
-    ALL_TECH_STACK_BADGES.flatMap((b) => [
+    ALL_TECH_STACK_BADGES.flatMap((b: Extract<TechStackChip, { off: string; on: string }>) => [
       [normalizeTechKey(b.key), b],
       [normalizeTechKey(b.label), b],
     ]),
@@ -86,10 +86,10 @@ export default function RecommendDeveloperCard({
     const normalized = normalizeTechKey(name);
     // 목데이터/백엔드에서 들어올 수 있는 표기 흔들림 대응
     const alias = normalized
-      .replaceAll('typescript', 'typescript')
-      .replaceAll('nextjs', 'nextjs')
-      .replaceAll('nodejs', 'nodejs')
-      .replaceAll('reactnative', 'reactnative');
+      .replace(/typescript/g, 'typescript')
+      .replace(/nextjs/g, 'nextjs')
+      .replace(/nodejs/g, 'nodejs')
+      .replace(/reactnative/g, 'reactnative');
     return TECH_BADGE_BY_NAME.get(alias) ?? TECH_BADGE_BY_NAME.get(normalized) ?? null;
   };
 

--- a/src/shared/constants/position-tech-stack.ts
+++ b/src/shared/constants/position-tech-stack.ts
@@ -160,16 +160,22 @@ export const INFRA_CONTAINER: TechStackChip[] = [
   { key: 'Kubernetes', label: 'Kubernetes', off: KubernetesOff, on: KubernetesOn, offDark: KubernetesOffDark, onDark: KubernetesOnDark },
 ];
 
-export const TECH_STACK_LABEL_BY_KEY: Record<string, string> = Object.fromEntries(
-  [
-    ...FRONTEND_LANGUAGE_FRAMEWORK,
-    ...FRONTEND_MOBILE,
-    ...BACKEND_LANGUAGE,
-    ...BACKEND_FRAMEWORK,
-    ...BACKEND_DATABASE,
-    ...INFRA_CLOUD,
-    ...INFRA_CONTAINER,
-  ].map((c) => [c.key, c.label]),
+const TECH_STACK_ENTRIES = [
+  ...FRONTEND_LANGUAGE_FRAMEWORK,
+  ...FRONTEND_MOBILE,
+  ...BACKEND_LANGUAGE,
+  ...BACKEND_FRAMEWORK,
+  ...BACKEND_DATABASE,
+  ...INFRA_CLOUD,
+  ...INFRA_CONTAINER,
+];
+
+export const TECH_STACK_LABEL_BY_KEY: Record<string, string> = TECH_STACK_ENTRIES.reduce<Record<string, string>>(
+  (acc, c) => {
+    acc[c.key] = c.label;
+    return acc;
+  },
+  {},
 );
 
 export type PositionKey = 'frontend' | 'backend' | 'infra';

--- a/src/shared/types/profileCard.types.ts
+++ b/src/shared/types/profileCard.types.ts
@@ -17,7 +17,7 @@ export type ProfileCardProps = {
 
   introduction?: string;
 
-  badges?: Array<{ label: string; tone: BadgeTone }>;
+  badges?: Array<{ id?: string; label: string; tone: BadgeTone }>;
   techStack?: TechStackItem[];
 
   bookmarked?: boolean;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2021",
-    "lib": ["ES2021", "DOM"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "moduleResolution": "node",

--- a/yarn.lock
+++ b/yarn.lock
@@ -231,7 +231,7 @@
 
 "@clerk/clerk-react@^5.60.0":
   version "5.60.0"
-  resolved "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.60.0.tgz"
+  resolved "https://registry.yarnpkg.com/@clerk/clerk-react/-/clerk-react-5.60.0.tgz#96ca8068fd5dbce0f4d96128a8e16e852ded32a1"
   integrity sha512-P88FncsJpq/3WZJhhlj+md8mYb35BIXpr462C/figwsBGHsinr8VuBQUMcMZZ/6M34C8ABfLTPa6PHVp6+3D5Q==
   dependencies:
     "@clerk/shared" "^3.44.0"


### PR DESCRIPTION
<!---- 해당 PR에 대한 설명을 작성해 주세요. !-->

## 🔎 개요

Vercel 배포 시 `yarn build`가 실패하는 문제를 수정했습니다.

**원인**
- 빌드 환경에서 TypeScript `lib`가 낮게 적용되어 `includes`, `replaceAll`, `flatMap`, `Object.fromEntries` 등을 인식하지 못함
- `ProfileBase`의 badge 타입에 `id`가 없어 `key` 사용 시 타입 에러 발생

**수정 내용**
- `tsconfig.json`: `lib`를 `["ES2022", "DOM", "DOM.Iterable"]`로 명시
- `report-create-page.tsx`: `includes` → `indexOf` (ES 호환)
- `profileCard.types.ts` / `ProfileBase.tsx`: badge 타입에 `id?` 추가, key에 fallback 적용
- `RecommendDeveloperCard.tsx`: `replaceAll` → `replace(/.../g, ...)`, flatMap 콜백에 타입 명시
- `position-tech-stack.ts`: `Object.fromEntries` → `reduce`로 객체 생성

UI/동작 변경 없이 빌드만 통과하도록 수정했습니다.

## 💡 해결한 이슈 목록

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제